### PR TITLE
make use of Update objects instead of Message objects

### DIFF
--- a/EventListener/CommandListener.php
+++ b/EventListener/CommandListener.php
@@ -1,8 +1,6 @@
 <?php
 /**
- * User: boshurik
- * Date: 30.05.16
- * Time: 18:03
+ * @author: boshurik, martcor
  */
 
 namespace BoShurik\TelegramBotBundle\EventListener;
@@ -36,14 +34,11 @@ class CommandListener
     public function onUpdate(UpdateEvent $event)
     {
         foreach ($this->commandPool->getCommands() as $command) {
-            if (!$message = $event->getUpdate()->getMessage()) {
-                continue;
-            }
-            if (!$command->isApplicable($message)) {
+            if (!$command->isApplicable($event->getUpdate())) {
                 continue;
             }
 
-            $command->execute($this->api, $message);
+            $command->execute($this->api, $event->getUpdate());
             $event->setProcessed();
 
             break;

--- a/Telegram/Command/AbstractCommand.php
+++ b/Telegram/Command/AbstractCommand.php
@@ -1,13 +1,11 @@
 <?php
 /**
- * User: boshurik
- * Date: 30.05.16
- * Time: 18:10
+ * @author: boshurik, martcor
  */
 
 namespace BoShurik\TelegramBotBundle\Telegram\Command;
 
-use TelegramBot\Api\Types\Message;
+use TelegramBot\Api\Types\Update;
 
 abstract class AbstractCommand implements CommandInterface
 {
@@ -32,8 +30,10 @@ abstract class AbstractCommand implements CommandInterface
     /**
      * @inheritDoc
      */
-    public function isApplicable(Message $message)
+    public function isApplicable(Update $update)
     {
+        $message = $update->getMessage();
+
         if (is_null($message) || !strlen($message->getText())) {
             return false;
         }

--- a/Telegram/Command/CommandInterface.php
+++ b/Telegram/Command/CommandInterface.php
@@ -1,27 +1,25 @@
 <?php
 /**
- * User: boshurik
- * Date: 25.04.16
- * Time: 13:59
+ * @author: boshurik, martcor
  */
 
 namespace BoShurik\TelegramBotBundle\Telegram\Command;
 
-use TelegramBot\Api\Types\Message;
 use TelegramBot\Api\BotApi;
+use TelegramBot\Api\Types\Update;
 
 interface CommandInterface
 {
     /**
      * @param BotApi $api
-     * @param Message $message
+     * @param Update $update
      * @return mixed
      */
-    public function execute(BotApi $api, Message $message);
+    public function execute(BotApi $api, Update $update);
 
     /**
-     * @param Message $message
+     * @param Update $update
      * @return boolean
      */
-    public function isApplicable(Message $message);
+    public function isApplicable(Update $update);
 }

--- a/Telegram/Command/HelpCommand.php
+++ b/Telegram/Command/HelpCommand.php
@@ -1,14 +1,13 @@
 <?php
 /**
- * User: boshurik
- * Date: 25.04.16
- * Time: 14:05
+ * @author: boshurik, martcor
  */
 
 namespace BoShurik\TelegramBotBundle\Telegram\Command;
 
 use TelegramBot\Api\BotApi;
 use TelegramBot\Api\Types\Message;
+use TelegramBot\Api\Types\Update;
 
 class HelpCommand extends AbstractCommand implements PublicCommandInterface
 {
@@ -37,7 +36,7 @@ class HelpCommand extends AbstractCommand implements PublicCommandInterface
     /**
      * @inheritDoc
      */
-    public function execute(BotApi $api, Message $message)
+    public function execute(BotApi $api, Update $update)
     {
         $commands = $this->commandPool->getCommands();
 
@@ -50,7 +49,7 @@ class HelpCommand extends AbstractCommand implements PublicCommandInterface
             $reply .= sprintf("%s - %s\n", $command->getName(), $command->getDescription());
         }
 
-        $api->sendMessage($message->getChat()->getId(), $reply);
+        $api->sendMessage($update->getMessage()->getChat()->getId(), $reply);
     }
 
     /**


### PR DESCRIPTION
In an Update comes [more](https://github.com/TelegramBot/Api/blob/master/src/Types/Update.php#L33) than only the Message object:

- InlineQuery
- ChosenInlineResult
- CallbackQuery
- ShippingQuery
- PreCheckoutQuery

If users want to make use of this, we should get all the data Telegram presents.
Could you make a new version and accept these changes?