### PR TITLE
Do not expect optional parameters as required

### DIFF
--- a/src/Guard/TelegramLoginValidator.php
+++ b/src/Guard/TelegramLoginValidator.php
@@ -19,8 +19,6 @@ class TelegramLoginValidator
 
     private const REQUIRED_FIELDS = [
         'id',
-        'first_name',
-        'last_name',
         'auth_date',
         'hash',
     ];

--- a/tests/Guard/TelegramLoginValidatorTest.php
+++ b/tests/Guard/TelegramLoginValidatorTest.php
@@ -94,4 +94,23 @@ class TelegramLoginValidatorTest extends TestCase
 
         $this->assertTrue(true, 'No exception was thrown on valid data');
     }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testPartialyPresentValidData(): void
+    {
+        $validator = new TelegramLoginValidator(self::TOKEN);
+
+        // Mock `time()` function
+        $time = $this->getFunctionMock('BoShurik\TelegramBotBundle\Guard', 'time');
+        $time->expects($this->once())->willReturn(0);
+
+        $validator->validate([
+            'id' => 0,
+            'auth_date' => 0,
+            'hash' => '68da7dc17d76484d189c16716db2abdabc8c8ae8d20e6690853ac7800b7e8204',
+        ]);
+    }
 }


### PR DESCRIPTION
Currently telegram doc states:
`by redirecting the user to the URL specified in the data-auth-url attribute with the following parameters: id, first_name, last_name, username, photo_url, auth_date and hash;`

but not all of the parameters will be present in redirect request query.
For example: if user hasnt set username, nor first or last name, nor uploaded a photo. Assuming that freshly registered account will be redirected only with id, auth_date and hash in query.