### PR TITLE
Fix deprecation in SetCommand

### DIFF
--- a/src/Command/Webhook/SetCommand.php
+++ b/src/Command/Webhook/SetCommand.php
@@ -106,7 +106,7 @@ final class SetCommand extends Command
         BotApi $api,
         string $urlOrHostname = null,
         \CURLFile $certificateFile = null,
-        array $allowedUpdates = null
+        ?array $allowedUpdates = null
     ): bool {
         $io->block(sprintf('Bot "%s"', $name));
 


### PR DESCRIPTION
Fixes the following deprecation notice:
```
symfony/vendor/boshurik/telegram-bot-bundle/src/Command/Webhook/SetCommand.php:103
BoShurik\TelegramBotBundle\Command\Webhook\SetCommand::setWebhook(): Implicitly marking parameter $allowedUpdates as nullable is deprecated, the explicit nullable type must be used instead
```